### PR TITLE
upgrade to api-29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/android:api-28-alpha
+FROM circleci/android:api-29
 ADD Gemfile* ./
 RUN sudo apt-get install build-essential make ruby-dev curl zlib1g-dev liblzma-dev \
     && sudo gem install bundler -v 1.16.0 \


### PR DESCRIPTION
In order to build the apk that targetSdkVersion is 29, we need to upgrade docker image to 29